### PR TITLE
for https://github.com/cidgoh/DataHarmonizer/issues/281

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,20 @@
 DEEP_PREF=../..
 CONVERSION_SCRIPT=script/linkml.py
 
-.PHONY: all clean
+.PHONY: all clean mix nmdc
 
 all: clean template/MIxS/schema.js template/nmdc_dh/schema.js
+mixs: clean template/MIxS/schema.js
+nmdc: clean template/nmdc_dh/schema.js
 
 clean:
 	rm -rf template/menu.js
 	rm -rf template/MIxS/schema.js
 	rm -rf template/nmdc_dh/schema.js
+	rm -rf template/nmdc_dh/source/nmdc_dh.yaml
+
+template/nmdc_dh/source/nmdc_dh.yaml:
+	wget https://raw.githubusercontent.com/microbiomedata/sheets_and_friends/main/artifacts/nmdc_dh.yaml -O $@
 
 template/MIxS/schema.js: template/MIxS/source/mixs.yaml
 	$(eval DIRNAME=$(shell dirname $@))

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@
 dpath==2.0.6
 black
 linkml_runtime
+linkml # Sujay suggested this instead


### PR DESCRIPTION
for https://github.com/cidgoh/DataHarmonizer/issues/281

- Illustrates broken validation button
- always pulls latest NMDC DH LinkML file
- new `nmdc` Makefile rule illustrates smaller size when the entire MIxS model is **not** included 
- tweaks to requirements.txt
