### PR TITLE
Prevent `self` variables from leaking into global namespace

### DIFF
--- a/script/data-harmonizer/toolbar.js
+++ b/script/data-harmonizer/toolbar.js
@@ -6,7 +6,7 @@ DataHarmonizerToolbar = {
 	 * Wire up user controls which only need to happen once on load of page.
 	 */
 	init: function (dh, dhToolbar) {
-		self = this; //For anonymous button functions etc.
+		const self = this; //For anonymous button functions etc.
 		this.dh = dh;
 
 		$('#version-dropdown-item').text('version ' + VERSION);
@@ -242,7 +242,7 @@ DataHarmonizerToolbar = {
 	},
 
 	refresh: function () {
-		self = this;
+		const self = this;
 		$('#select-template').val(this.dh.template_path);
 		$('#template_name_display').text(this.dh.template_path);
 		$('#file_name_display').text('');
@@ -293,7 +293,7 @@ DataHarmonizerToolbar = {
 	 * Show available templates, with sensitivity to "view draft template" checkbox
 	 */
 	templateOptions: function (dh) {
-		self = this;
+		const self = this;
 		// Select menu for available templates
 		const select = $("#select-template");
 		select.empty();

--- a/script/data-harmonizer/validation.js
+++ b/script/data-harmonizer/validation.js
@@ -266,7 +266,7 @@ Object.assign(DataHarmonizer, {
 	*         [true, string] If every value in `delimited_string` is in `source` but formatting needs change
 	*/
 	validateValsAgainstVocab: function (delimited_string, source) {
-		self = this;
+		const self = this;
 		let update_flag = false;
 		let value_array = delimited_string.split(';');
 		value_array.forEach(function (value, index) {


### PR DESCRIPTION
Fixes #288 

There was a missing step in the instructions of that issue. The problem only occurs _after_ running validation. Prior to this change `toolbar.js` was leaking the variable `self` into the global namespace and that variable was overwritten later on by `validation.js`. The fix is to keep those variables properly scoped. 