### PR TITLE
Handle minimum_value and maximum_value slots

### DIFF
--- a/script/data-harmonizer/index.js
+++ b/script/data-harmonizer/index.js
@@ -1210,8 +1210,11 @@ let DataHarmonizer = {
 	 * @return {String} HTML string describing field.
 	 */
 	getComment: function (field) {
-	  let ret = `<p><strong>Label</strong>: ${field.title}</p>
-	<p><strong>Description</strong>: ${field.description}</p>`;
+	  let ret = `<p><strong>Label</strong>: ${field.title}</p>`;
+
+	  if (field.description) {
+		ret += `<p><strong>Description</strong>: ${field.description}</p>`;
+	  }
 
 	  let guidance = [];
 	  if (field.comments && field.comments.length) {

--- a/script/data-harmonizer/index.js
+++ b/script/data-harmonizer/index.js
@@ -1011,15 +1011,6 @@ let DataHarmonizer = {
 				new_field['title'] = new_field['name'];
 			}
 
-			// The presence of a min/max value implies that this field is numeric
-			// and should be validated as such. But a lot of slots don't define
-			// a `range` along with `minimum_value` or `maximum_value`. This is a 
-			// hack to get the validation to work even though this should really
-			// be handled by defining an appropriate `range` in the schema.
-			if ('minimum_value' in new_field || 'maximum_value' in new_field) {
-				new_field.range = 'float'
-			}
-
 			new_field.datatype = null;
 			switch (new_field.range) {
 				// LinkML typically translates "string" to "uri":"xsd:string" but

--- a/script/data-harmonizer/index.js
+++ b/script/data-harmonizer/index.js
@@ -1214,6 +1214,19 @@ let DataHarmonizer = {
 	  if (field.string_serialization) {
 		guidance.push('Pattern hint: ' + field.string_serialization);
 	  }
+	  const hasMinValue = field.minimum_value != null;
+	  const hasMaxValue = field.maximum_value != null;
+	  if (hasMinValue || hasMaxValue) {
+		  let paragraph = 'Value should be '
+		  if (hasMinValue && hasMaxValue) {
+			  paragraph += `between ${field.minimum_value} and ${field.maximum_value}.`
+		  } else if (hasMinValue) {
+			  paragraph += `greater than ${field.minimum_value}.`
+		  } else if (hasMaxValue) {
+			  paragraph += `less than ${field.maximum_value}.`
+		  }
+		  guidance.push(paragraph);
+	  }
 	  if (guidance.length) {
 		guidance[0] = '<strong>Guidance</strong>: ' + guidance[0]
 		const renderedParagraphs = guidance

--- a/script/data-harmonizer/index.js
+++ b/script/data-harmonizer/index.js
@@ -1231,11 +1231,11 @@ let DataHarmonizer = {
 	  if (hasMinValue || hasMaxValue) {
 		  let paragraph = 'Value should be '
 		  if (hasMinValue && hasMaxValue) {
-			  paragraph += `between ${field.minimum_value} and ${field.maximum_value}.`
+			  paragraph += `between ${field.minimum_value} and ${field.maximum_value} (inclusive).`
 		  } else if (hasMinValue) {
-			  paragraph += `greater than ${field.minimum_value}.`
+			  paragraph += `greater than or equal to ${field.minimum_value}.`
 		  } else if (hasMaxValue) {
-			  paragraph += `less than ${field.maximum_value}.`
+			  paragraph += `less than or equal to ${field.maximum_value}.`
 		  }
 		  guidance.push(paragraph);
 	  }

--- a/script/data-harmonizer/index.js
+++ b/script/data-harmonizer/index.js
@@ -1011,6 +1011,15 @@ let DataHarmonizer = {
 				new_field['title'] = new_field['name'];
 			}
 
+			// The presence of a min/max value implies that this field is numeric
+			// and should be validated as such. But a lot of slots don't define
+			// a `range` along with `minimum_value` or `maximum_value`. This is a 
+			// hack to get the validation to work even though this should really
+			// be handled by defining an appropriate `range` in the schema.
+			if ('minimum_value' in new_field || 'maximum_value' in new_field) {
+				new_field.range = 'float'
+			}
+
 			new_field.datatype = null;
 			switch (new_field.range) {
 				// LinkML typically translates "string" to "uri":"xsd:string" but


### PR DESCRIPTION
These changes add information from the `minimum_value` and `maximum_value` slots to the guidance paragraph in the column help popup. I also added a small hack-ish fix which allows those slots to be be used in validation even if the class does not have a `range` defined. That should be fixed at the schema level, but that might take some more time to get working.