### PR TITLE
Allow `getDataObjects` to include data that doesn't conform to column types

### DIFF
--- a/lib/DataHarmonizer.js
+++ b/lib/DataHarmonizer.js
@@ -1341,16 +1341,19 @@ class DataHarmonizer {
 
   /**
    * Get grid data as a list of objects. The keys of each object are the
-   * field names and the values are parsed according to the field's datatype.
+   * field names and the values are parsed according to the field's datatype
+   * if the `strict` parameter is true (default). If `strict` is false, no
+   * parsing is done and all values will be strings.
    *
+   * @param {boolean} strict Exclude values that don't adhere to column data types
    * @return {Array<Object>}
    */
-  getDataObjects() {
+  getDataObjects(strict = true) {
     const listData = this.hot.getData();
     const fields = this.getFields();
     return listData
       .filter((row) => row.some((cell) => cell !== '' && cell != null))
-      .map((row) => dataArrayToObject(row, fields));
+      .map((row) => dataArrayToObject(row, fields, { strict: strict }));
   }
 
   /**

--- a/lib/utils/fields.js
+++ b/lib/utils/fields.js
@@ -41,13 +41,12 @@ export function fieldUnitBinTest(fields, col) {
 const DATA_ARRAY_TO_OBJECT_OPTION_DEFAULTS = {
   multivalueDelimiter: '; ',
   strict: true,
-}
-export function dataArrayToObject(
-  dataArray,
-  fields,
-  options = {},
-) {
-  const { multivalueDelimiter, strict } = {...DATA_ARRAY_TO_OBJECT_OPTION_DEFAULTS, ...options}
+};
+export function dataArrayToObject(dataArray, fields, options = {}) {
+  const { multivalueDelimiter, strict } = {
+    ...DATA_ARRAY_TO_OBJECT_OPTION_DEFAULTS,
+    ...options,
+  };
   const dataObject = {};
   dataArray.forEach((cell, idx) => {
     if (cell === '' || cell == null) {
@@ -58,7 +57,7 @@ export function dataArrayToObject(
     if (field.multivalued) {
       const split = cell.split(multivalueDelimiter);
       parsed = split
-        .map((value) => strict ? parseDatatype(value, field.datatype) : value)
+        .map((value) => (strict ? parseDatatype(value, field.datatype) : value))
         .filter((parsed) => parsed !== undefined);
       if (parsed.length > 0) {
         dataObject[field.name] = parsed;

--- a/lib/utils/fields.js
+++ b/lib/utils/fields.js
@@ -38,11 +38,16 @@ export function fieldUnitBinTest(fields, col) {
   );
 }
 
+const DATA_ARRAY_TO_OBJECT_OPTION_DEFAULTS = {
+  multivalueDelimiter: '; ',
+  strict: true,
+}
 export function dataArrayToObject(
   dataArray,
   fields,
-  multivalueDelimiter = '; '
+  options = {},
 ) {
+  const { multivalueDelimiter, strict } = {...DATA_ARRAY_TO_OBJECT_OPTION_DEFAULTS, ...options}
   const dataObject = {};
   dataArray.forEach((cell, idx) => {
     if (cell === '' || cell == null) {
@@ -53,13 +58,13 @@ export function dataArrayToObject(
     if (field.multivalued) {
       const split = cell.split(multivalueDelimiter);
       parsed = split
-        .map((value) => parseDatatype(value, field.datatype))
+        .map((value) => strict ? parseDatatype(value, field.datatype) : value)
         .filter((parsed) => parsed !== undefined);
       if (parsed.length > 0) {
         dataObject[field.name] = parsed;
       }
     } else {
-      parsed = parseDatatype(cell, field.datatype);
+      parsed = strict ? parseDatatype(cell, field.datatype) : cell;
       if (parsed !== undefined) {
         dataObject[field.name] = parsed;
       }

--- a/tests/fields.test.js
+++ b/tests/fields.test.js
@@ -67,4 +67,14 @@ describe('dataArrayToObject', () => {
       f: [5, 18],
     });
   });
+
+  test('includes all values when strict = false', () => {
+    const dataArray = ['5.85', '21.25', '', '', '', '5; asdf; 18'];
+    const dataObject = dataArrayToObject(dataArray, fields, { strict: false });
+    expect(dataObject).toEqual({
+      a: "5.85",
+      b: "21.25",
+      f: ["5", "asdf", "18"],
+    });
+  })
 });

--- a/tests/fields.test.js
+++ b/tests/fields.test.js
@@ -72,9 +72,9 @@ describe('dataArrayToObject', () => {
     const dataArray = ['5.85', '21.25', '', '', '', '5; asdf; 18'];
     const dataObject = dataArrayToObject(dataArray, fields, { strict: false });
     expect(dataObject).toEqual({
-      a: "5.85",
-      b: "21.25",
-      f: ["5", "asdf", "18"],
+      a: '5.85',
+      b: '21.25',
+      f: ['5', 'asdf', '18'],
     });
-  })
+  });
 });


### PR DESCRIPTION
This adds a `strict` option to both `DataHarmonizer.getDataObjects` and the `dataArrayToObject` utility function in `fields.js`. If `strict` is `true` (the default if not provided) there is no change in behavior. If `strict` is `false` column datatypes are not used to parse table values. This means that the value "xyz" _will_ be included even if it was entered in an integer column. Necessarily, all values will be strings if `strict` is `false`.

Fixes #350 