### PR TITLE
Add method for loading data as array of objects

### DIFF
--- a/lib/DataHarmonizer.js
+++ b/lib/DataHarmonizer.js
@@ -8,6 +8,7 @@ import { readFileAsync, updateSheetRange } from './utils/files';
 import {
   changeCase,
   dataArrayToObject,
+  dataObjectToArray,
   fieldUnitBinTest,
 } from './utils/fields';
 import { parseDatatype } from './utils/datatypes';
@@ -1351,6 +1352,18 @@ class DataHarmonizer {
     return listData
       .filter((row) => row.some((cell) => cell !== '' && cell != null))
       .map((row) => dataArrayToObject(row, fields));
+  }
+
+  /**
+   * Load data into table as an array of objects. The keys of each object are
+   * field names and the values are the cell values.
+   *
+   * @param {Array<Object>} data table data
+   */
+  loadDataObjects(data) {
+    const fields = this.getFields();
+    const listData = data.map((row) => dataObjectToArray(row, fields));
+    this.hot.loadData(this.matrixFieldChangeRules(listData));
   }
 
   /**

--- a/lib/utils/datatypes.js
+++ b/lib/utils/datatypes.js
@@ -1,4 +1,4 @@
-import { parse } from 'date-fns';
+import { format, parse } from 'date-fns';
 
 function integer(value) {
   const correctPattern = /^[-+]?[0-9]+$/.test(value);
@@ -33,12 +33,18 @@ function bool(value) {
   }
 }
 
-function date(value) {
-  const parsed = parse(value, 'yyyy-MM-dd', new Date());
+const DATE_FORMAT = 'yyyy-MM-dd';
+
+function parseDate(value) {
+  const parsed = parse(value, DATE_FORMAT, new Date());
   if (isNaN(parsed)) {
     return undefined;
   }
   return parsed;
+}
+
+function stringifyDate(value) {
+  return format(value, DATE_FORMAT);
 }
 
 const PARSERS = {
@@ -48,11 +54,27 @@ const PARSERS = {
   'xsd:double': float,
   'xsd:decimal': decimal,
   'xsd:boolean': bool,
-  'xsd:date': date,
+  'xsd:date': parseDate,
+};
+
+const STRINGIFIERS = {
+  'xsd:date': stringifyDate,
 };
 
 export function parseDatatype(value, datatype) {
   const parser = PARSERS[datatype];
   const parsed = parser ? parser(value) : value;
   return parsed;
+}
+
+export function stringifyDatatype(value, datatype) {
+  if (value === null || value === undefined) {
+    return '';
+  }
+  if (typeof value === 'string') {
+    return value;
+  }
+  const stringifier = STRINGIFIERS[datatype];
+  const stringified = stringifier ? stringifier(value) : String(value);
+  return stringified;
 }

--- a/lib/utils/fields.js
+++ b/lib/utils/fields.js
@@ -1,4 +1,4 @@
-import { parseDatatype } from './datatypes';
+import { parseDatatype, stringifyDatatype } from './datatypes';
 
 /**
  * Modify a string to match specified case.
@@ -66,4 +66,31 @@ export function dataArrayToObject(
     }
   });
   return dataObject;
+}
+
+const DATA_OBJECT_TO_ARRAY_DEFAULT_OPTIONS = {
+  multivalueDelimiter: '; ',
+};
+export function dataObjectToArray(dataObject, fields, options = {}) {
+  const { multivalueDelimiter } = {
+    ...DATA_OBJECT_TO_ARRAY_DEFAULT_OPTIONS,
+    ...options,
+  };
+  const dataArray = Array(fields.length).fill('');
+  for (const [key, value] of Object.entries(dataObject)) {
+    const fieldIdx = fields.findIndex((f) => f.name === key);
+    if (fieldIdx < 0) {
+      console.warn('Could not map data object key ' + key);
+      continue;
+    }
+    const field = fields[fieldIdx];
+    if (field.multivalued && Array.isArray(value)) {
+      dataArray[fieldIdx] = value
+        .map((v) => stringifyDatatype(v, field.datatype))
+        .join(multivalueDelimiter);
+    } else {
+      dataArray[fieldIdx] = stringifyDatatype(value, field.datatype);
+    }
+  }
+  return dataArray;
 }

--- a/tests/datatypes.test.js
+++ b/tests/datatypes.test.js
@@ -1,4 +1,4 @@
-import { parseDatatype } from '../lib/utils/datatypes';
+import { parseDatatype, stringifyDatatype } from '../lib/utils/datatypes';
 
 test.each([
   // value, datatype, expected
@@ -78,5 +78,18 @@ test.each([
   ['whatever', 'unknown', 'whatever'],
 ])('parseDatatype(%s, %s)', (value, datatype, expected) => {
   const actual = parseDatatype(value, datatype);
+  expect(actual).toEqual(expected);
+});
+
+test.each([
+  [103, 'xsd:integer', '103'],
+  [33, 'xsd:nonNegativeInteger', '33'],
+  [0.1217, 'xsd:float', '0.1217'],
+  [-42.19, 'xsd:double', '-42.19'],
+  [1.1, 'xsd:decimal', '1.1'],
+  [true, 'xsd:boolean', 'true'],
+  [new Date(1993, 3, 16), 'xsd:date', '1993-04-16'],
+])('stringifyDatatype(%s, %s)', (value, datatype, expected) => {
+  const actual = stringifyDatatype(value, datatype);
   expect(actual).toEqual(expected);
 });

--- a/tests/fields.test.js
+++ b/tests/fields.test.js
@@ -1,35 +1,35 @@
-import { dataArrayToObject } from '../lib/utils/fields';
+import { dataArrayToObject, dataObjectToArray } from '../lib/utils/fields';
+
+const fields = [
+  {
+    name: 'a',
+    datatype: 'xsd:integer',
+  },
+  {
+    name: 'b',
+    datatype: 'xsd:float',
+  },
+  {
+    name: 'c',
+    datatype: 'xsd:boolean',
+  },
+  {
+    name: 'd',
+    datatype: 'xsd:date',
+  },
+  {
+    name: 'e',
+    datatype: 'xsd:token',
+    multivalued: true,
+  },
+  {
+    name: 'f',
+    datatype: 'xsd:float',
+    multivalued: true,
+  },
+];
 
 describe('dataArrayToObject', () => {
-  const fields = [
-    {
-      name: 'a',
-      datatype: 'xsd:integer',
-    },
-    {
-      name: 'b',
-      datatype: 'xsd:float',
-    },
-    {
-      name: 'c',
-      datatype: 'xsd:boolean',
-    },
-    {
-      name: 'd',
-      datatype: 'xsd:date',
-    },
-    {
-      name: 'e',
-      datatype: 'xsd:token',
-      multivalued: true,
-    },
-    {
-      name: 'f',
-      datatype: 'xsd:float',
-      multivalued: true,
-    },
-  ];
-
   test('returns object with correct datatypes', () => {
     const dataArray = ['1', '1.5', '1', '2018-02-15'];
     const dataObject = dataArrayToObject(dataArray, fields);
@@ -66,5 +66,28 @@ describe('dataArrayToObject', () => {
       b: 21.25,
       f: [5, 18],
     });
+  });
+});
+
+describe('dataObjectToArray', () => {
+  test('returns data array with correct elements populated', () => {
+    const dataObject = {
+      a: 1,
+      b: 1.5,
+      c: true,
+      d: new Date(2018, 1, 15),
+    };
+    const dataArray = dataObjectToArray(dataObject, fields);
+    expect(dataArray).toEqual(['1', '1.5', 'true', '2018-02-15', '', '']);
+  });
+
+  test('returns delimited strings for multivalued fields', () => {
+    const dataObject = {
+      b: 33.333,
+      e: ['a', 'b', 'c'],
+      f: 33,
+    };
+    const dataArray = dataObjectToArray(dataObject, fields);
+    expect(dataArray).toEqual(['', '33.333', '', '', 'a; b; c', '33']);
   });
 });


### PR DESCRIPTION
These changes add a `DataHarmonizer.loadDataObjects` method to compliment `DataHarmonizer.getDataObjects`. The array of data objects are unpacked into an array of arrays of strings by a new utility function (`dataObjectToArray`). That function handles joining values of multivalued columns. Most of the conversion of values to strings is done by the native `String` constructor, except for dates which are string-ified according to the same format used elsewhere. This happens in the new `stringifyDatatype` utility function in `datatypes.js`.

Fixes #351 