### PR TITLE
Proposal: 

### DIFF
--- a/lib/DataHarmonizer.js
+++ b/lib/DataHarmonizer.js
@@ -10,6 +10,7 @@ import {
   dataArrayToObject,
   dataObjectToArray,
   fieldUnitBinTest,
+  getFieldSettingsFromUiConfig,
 } from './utils/fields';
 import { parseDatatype } from './utils/datatypes';
 import {
@@ -51,8 +52,9 @@ class DataHarmonizer {
     this.schema = options.schema;
     this.loadingScreenRoot = options.loadingScreenRoot || this.root;
     this.modalsRoot = options.modalsRoot || document.querySelector('body');
-    this.field_settings = options.fieldSettings || {};
-    this.self = this;
+
+    const fieldSettings = getFieldSettingsFromUiConfig(options.uiConfig);
+    this.field_settings = Object.assign(fieldSettings, options.fieldSettings);
 
     this.injectLoadingScreen();
 

--- a/lib/utils/fields.js
+++ b/lib/utils/fields.js
@@ -100,7 +100,7 @@ export function dataObjectToArray(dataObject, fields, options = {}) {
 }
 
 function olsAutocompleteFieldSettings(config) {
-  const { ontology } = config
+  const { ontology } = config;
   return {
     getColumn: (dh, col) => {
       let timer = null;
@@ -111,47 +111,49 @@ function olsAutocompleteFieldSettings(config) {
         allowInvalid: false,
         sortByRelevance: false,
         source: (query, next) => {
-          clearTimeout(timer)
+          clearTimeout(timer);
           if (!query) {
-            return next([])
+            return next([]);
           }
           timer = setTimeout(() => {
-            fetch(`https://www.ebi.ac.uk/ols/api/select?q=${query}&ontology=${ontology}&type=class&rows=50`)
-            .then(response => {
-              if (!response.ok) {
-                throw new Error('API Error: ' + response.status)
-              }
-              return response.json()
-            })
-            .then(body => {
-              const options = body.response.docs.map(doc => doc.label)
-              next(options)
-            })
-            .catch(() => {
-              next([])
-            })
-          }, 300)
+            fetch(
+              `https://www.ebi.ac.uk/ols/api/select?q=${query}&ontology=${ontology}&type=class&rows=50`
+            )
+              .then((response) => {
+                if (!response.ok) {
+                  throw new Error('API Error: ' + response.status);
+                }
+                return response.json();
+              })
+              .then((body) => {
+                const options = body.response.docs.map((doc) => doc.label);
+                next(options);
+              })
+              .catch(() => {
+                next([]);
+              });
+          }, 300);
         },
-      }
-    }
-  }
+      };
+    },
+  };
 }
 
 const WIDGET_REGISTRY = {
-  'ols-autocomplete': olsAutocompleteFieldSettings
-}
+  'ols-autocomplete': olsAutocompleteFieldSettings,
+};
 
 export function getFieldSettingsFromUiConfig(uiConfig) {
-  const fieldSettings = {}
+  const fieldSettings = {};
   if (uiConfig && uiConfig.fields) {
     for (const [field, config] of Object.entries(uiConfig.fields)) {
       if (config.widget in WIDGET_REGISTRY) {
-        const settingsFn = WIDGET_REGISTRY[config.widget]
-        fieldSettings[field] = settingsFn(config)
+        const settingsFn = WIDGET_REGISTRY[config.widget];
+        fieldSettings[field] = settingsFn(config);
       } else {
-        console.warn(`Unknown widget type: ${config.widget}`)
+        console.warn(`Unknown widget type: ${config.widget}`);
       }
     }
   }
-  return fieldSettings
+  return fieldSettings;
 }

--- a/lib/utils/fields.js
+++ b/lib/utils/fields.js
@@ -98,3 +98,60 @@ export function dataObjectToArray(dataObject, fields, options = {}) {
   }
   return dataArray;
 }
+
+function olsAutocompleteFieldSettings(config) {
+  const { ontology } = config
+  return {
+    getColumn: (dh, col) => {
+      let timer = null;
+      return {
+        ...col,
+        type: 'autocomplete',
+        strict: true,
+        allowInvalid: false,
+        sortByRelevance: false,
+        source: (query, next) => {
+          clearTimeout(timer)
+          if (!query) {
+            return next([])
+          }
+          timer = setTimeout(() => {
+            fetch(`https://www.ebi.ac.uk/ols/api/select?q=${query}&ontology=${ontology}&type=class&rows=50`)
+            .then(response => {
+              if (!response.ok) {
+                throw new Error('API Error: ' + response.status)
+              }
+              return response.json()
+            })
+            .then(body => {
+              const options = body.response.docs.map(doc => doc.label)
+              next(options)
+            })
+            .catch(() => {
+              next([])
+            })
+          }, 300)
+        },
+      }
+    }
+  }
+}
+
+const WIDGET_REGISTRY = {
+  'ols-autocomplete': olsAutocompleteFieldSettings
+}
+
+export function getFieldSettingsFromUiConfig(uiConfig) {
+  const fieldSettings = {}
+  if (uiConfig && uiConfig.fields) {
+    for (const [field, config] of Object.entries(uiConfig.fields)) {
+      if (config.widget in WIDGET_REGISTRY) {
+        const settingsFn = WIDGET_REGISTRY[config.widget]
+        fieldSettings[field] = settingsFn(config)
+      } else {
+        console.warn(`Unknown widget type: ${config.widget}`)
+      }
+    }
+  }
+  return fieldSettings
+}

--- a/web/index.js
+++ b/web/index.js
@@ -12,13 +12,13 @@ document.addEventListener('DOMContentLoaded', function () {
   // this is defined inline for convenience but could just as easily be
   // imported from a JSON file
   const uiConfig = {
-    'fields': {
+    fields: {
       'third party lab service provider name': {
-        'widget': 'ols-autocomplete',
-        'ontology': 'zfa,zfs'
-      }
-    }
-  }
+        widget: 'ols-autocomplete',
+        ontology: 'zfa,zfs',
+      },
+    },
+  };
 
   const dh = new DataHarmonizer(dhRoot, {
     loadingScreenRoot: document.querySelector('body'),

--- a/web/index.js
+++ b/web/index.js
@@ -9,8 +9,20 @@ document.addEventListener('DOMContentLoaded', function () {
   const dhFooterRoot = document.querySelector('#data-harmonizer-footer');
   const dhToolbarRoot = document.querySelector('#data-harmonizer-toolbar');
 
+  // this is defined inline for convenience but could just as easily be
+  // imported from a JSON file
+  const uiConfig = {
+    'fields': {
+      'third party lab service provider name': {
+        'widget': 'ols-autocomplete',
+        'ontology': 'zfa,zfs'
+      }
+    }
+  }
+
   const dh = new DataHarmonizer(dhRoot, {
     loadingScreenRoot: document.querySelector('body'),
+    uiConfig: uiConfig,
   });
 
   new Footer(dhFooterRoot, dh);


### PR DESCRIPTION
This is just a starting point of a discussion and not necessarily fully thought-out yet.

The basic idea is that a schema (LinkML or otherwise) generally can't capture _everything_ about how a tool to collect data adhering to that schema should look or behave. Obviously the schema can inform some sensible defaults (i.e. provide a dropdown menu when a value must be chosen from an enumeration) but it can't capture things like "suggest terms retrieved from this arbitrary endpoint". Or "this field should be omitted from the entry UI because it will be populated by a separate process" (see https://github.com/cidgoh/DataHarmonizer/issues/337). For use cases like these that are common enough, it would be nice for data-harmonizer clients to not have to write a lot of custom code and instead simply provide some configuration.

The changes here represent a very basic sketch of what a UI configuration approach might look like. A data-harmonizer application (i.e. `web/index.js`) provides a UI configuration object to the `DataHarmonizer` constructor (an application could even store this configuration in a standalone JSON file). The `DataHarmonizer` class is responsible for interpreting this configuration and applying the correct settings internally. The specific example implemented here is directing the `DataHarmonizer` instance to use an OLS-based autocomplete for a particular field. 

It's not implemented in this proof-of-concept, but you could also imagine a UI config like:

```json
{
  "fields": {
    "internal_id": {
      "hidden": true
    },
    "look_but_dont_touch": {
      "readonly": true
    }
  }
}
```

I could also imagine non-field-specific configuration going outside of the "fields" key (e.g. https://github.com/cidgoh/DataHarmonizer/issues/334):

```json
{
  "numFrozenColumns": 2
  "fields": {
    ...
  }
}
```

Again, this is just a conversation starter. I'd be interested to know if this might address (or not) other cases.

cc: @ddooley 