### PR TITLE
Clear existing Jump To click handler before adding it

### DIFF
--- a/lib/Toolbar.js
+++ b/lib/Toolbar.js
@@ -349,7 +349,10 @@ class Toolbar {
       options: options,
       openOnFocus: true,
     });
-    $jumpToInput.on('change', (e) => {
+    $jumpToInput.off('change').on('change', (e) => {
+      if (!e.target.value) {
+        return;
+      }
       const columnX = columnCoordinates[e.target.value];
       this.dh.scrollTo(0, columnX);
       $('#jump-to-modal').modal('hide');


### PR DESCRIPTION
jQuery's `.on` method _appends_ new event handler methods to the target. This means that each time `loadSelectedTemplate` is called a new change handler (along with its closure) is appended to `$jumpToInput`. This causes handlers with stale `columnCoordinates` values to be called on change. The fix is to remove old handlers via the `.off` method before adding a new one.