### PR TITLE
Add support for unique_keys field in LinkML classes

### DIFF
--- a/lib/DataHarmonizer.js
+++ b/lib/DataHarmonizer.js
@@ -1994,6 +1994,9 @@ class DataHarmonizer {
     let TODAY = new Date();
 
     let provenanceChanges = [];
+    const indexToRowMap = new Map();
+    const rowToIndexMap = new Map();
+    let index = 0;
 
     let bad_pattern = {};
 
@@ -2008,6 +2011,11 @@ class DataHarmonizer {
 
     for (let row = 0; row < this.hot.countRows(); row++) {
       if (this.hot.isEmptyRow(row)) continue;
+
+      // bookkeeping for non-empty rows
+      indexToRowMap.set(index, row);
+      rowToIndexMap.set(row, index);
+      index += 1;
 
       for (let col = 0; col < fields.length; col++) {
         const cellVal = this.hot.getDataAtCell(row, col);
@@ -2176,11 +2184,12 @@ class DataHarmonizer {
         } else {
           return this.hot
             .getDataAtCol(columnNumber)
-            .filter((val) => val != null);
+            .filter((_, row) => rowToIndexMap.has(row));
         }
       });
       const isUnique = validateUniqueValues(values);
-      isUnique.forEach((unique, row) => {
+      isUnique.forEach((unique, uniqueIndex) => {
+        const row = indexToRowMap.get(uniqueIndex);
         if (!unique) {
           if (!invalidCells[row]) {
             invalidCells[row] = {};

--- a/lib/DataHarmonizer.js
+++ b/lib/DataHarmonizer.js
@@ -18,6 +18,7 @@ import {
   testNumericRange,
   validateValAgainstVocab,
   validateValsAgainstVocab,
+  validateUniqueValues,
 } from './utils/validation';
 
 import 'handsontable/dist/handsontable.full.css';
@@ -45,6 +46,7 @@ class DataHarmonizer {
   // Currently selected cell range[row,col,row2,col2]
   current_selection = [null, null, null, null];
   field_settings = {};
+  template_unique_keys = [];
 
   constructor(root, options = {}) {
     this.root = root;
@@ -122,6 +124,8 @@ class DataHarmonizer {
       range: "date",
       ...
       */
+
+    this.template_unique_keys = specification.unique_keys ? Object.values(specification.unique_keys) : [];
 
     for (let name in specification.slots) {
       // ISSUE: a template's slot definition via SchemaView() currently
@@ -1987,8 +1991,6 @@ class DataHarmonizer {
     const columnIndex = this.getFieldYCoordinates();
     let TODAY = new Date();
 
-    let uniquefield = []; // holds lookup dictionary for any unique columns
-
     let provenanceChanges = [];
 
     let bad_pattern = {};
@@ -2155,24 +2157,6 @@ class DataHarmonizer {
           }
         } // End of field-not empty section
 
-        // Unique value field (Usually xsd:token string)
-        // CORRECT PLACE FOR THIS?
-        if (field.identifier && field.identifier === true) {
-          // Set up dictionary and count for this column's unique values
-          if (!uniquefield[col]) {
-            uniquefield[col] = {};
-            for (let keyrow = 0; keyrow < this.hot.countRows(); keyrow++) {
-              if (!this.hot.isEmptyRow(keyrow)) {
-                let key = this.hot.getDataAtCell(keyrow, col);
-                if (key in uniquefield[col]) uniquefield[col][key] += 1;
-                else uniquefield[col][key] = 1;
-              }
-            }
-          }
-          // Must be only 1 unique value.  Case insensitive comparison
-          valid &= uniquefield[col][cellVal] === 1;
-        }
-
         if (!valid) {
           if (!Object.prototype.hasOwnProperty.call(invalidCells, row)) {
             invalidCells[row] = {};
@@ -2181,6 +2165,44 @@ class DataHarmonizer {
         }
       } // column/field loop end
     } // row loop end
+
+    // Check row uniqueness for identifier fields and unique_key sets
+    const doUniqueValidation = (columnNumbers) => {
+      const values = columnNumbers.map((columnNumber) => {
+        if (columnNumber < 0) {
+          return [];
+        } else {
+          return this.hot
+            .getDataAtCol(columnNumber)
+            .filter((val) => val != null);
+        }
+      });
+      const isUnique = validateUniqueValues(values);
+      isUnique.forEach((unique, row) => {
+        if (!unique) {
+          if (!invalidCells[row]) {
+            invalidCells[row] = {};
+          }
+          columnNumbers.forEach((columnNumber) => {
+            invalidCells[row][columnNumber] = 'value must be unique';
+          });
+        }
+      });
+    }
+
+    const identifierFieldCol = fields.findIndex(
+      (field) => field.identifier && field.identifier === true
+    );
+    if (identifierFieldCol >= 0) {
+      doUniqueValidation([identifierFieldCol])
+    }
+
+    for (const unique_key of this.template_unique_keys) {
+      const uniqueKeyCols = unique_key.unique_key_slots.map(fieldName => {
+        return fields.findIndex((field) => field.name === fieldName);
+      })
+      doUniqueValidation(uniqueKeyCols);
+    }
 
     // Here an array of (row, column, value)... is being passed
     if (provenanceChanges.length) this.hot.setDataAtCell(provenanceChanges);

--- a/lib/DataHarmonizer.js
+++ b/lib/DataHarmonizer.js
@@ -125,7 +125,9 @@ class DataHarmonizer {
       ...
       */
 
-    this.template_unique_keys = specification.unique_keys ? Object.values(specification.unique_keys) : [];
+    this.template_unique_keys = specification.unique_keys
+      ? Object.values(specification.unique_keys)
+      : [];
 
     for (let name in specification.slots) {
       // ISSUE: a template's slot definition via SchemaView() currently
@@ -2188,19 +2190,19 @@ class DataHarmonizer {
           });
         }
       });
-    }
+    };
 
     const identifierFieldCol = fields.findIndex(
       (field) => field.identifier && field.identifier === true
     );
     if (identifierFieldCol >= 0) {
-      doUniqueValidation([identifierFieldCol])
+      doUniqueValidation([identifierFieldCol]);
     }
 
     for (const unique_key of this.template_unique_keys) {
-      const uniqueKeyCols = unique_key.unique_key_slots.map(fieldName => {
+      const uniqueKeyCols = unique_key.unique_key_slots.map((fieldName) => {
         return fields.findIndex((field) => field.name === fieldName);
-      })
+      });
       doUniqueValidation(uniqueKeyCols);
     }
 

--- a/lib/utils/validation.js
+++ b/lib/utils/validation.js
@@ -115,6 +115,13 @@ export function validateValsAgainstVocab(delimited_string, field) {
 }
 
 /**
+ * This function accepts an array of arrays. The inner arrays should contain
+ * null or primitive values. The return value is an array of booleans with
+ * the same length as the longest inner array of the input. The value of the
+ * n-th element of the output is true if the combination of n-th elements from
+ * each input array is distinct from the m-th elements of the input arrays for
+ * all m != n. In the case where there is only one inner array in the input,
+ * this is identical to determining whether each element of the array is unique.
  *
  * @param {Array<Array<any>>} columns to validate
  * @return {Array<boolean>}
@@ -122,24 +129,37 @@ export function validateValsAgainstVocab(delimited_string, field) {
  */
 export function validateUniqueValues(values) {
   const results = [];
+
+  // In the event that the column arrays are of unequal length, make sure
+  // that we iterate through the longest one.
   const longestColumn = Math.max.apply(
     null,
     values.map((col) => col.length)
   );
-  for (let self = 0; self < longestColumn; self += 1) {
-    let valid = true;
-    const selfValue = values.map((col) => col[self]);
-    for (let other = 0; other < self; other += 1) {
-      const otherValue = values.map((col) => col[other]);
-      const valuesEqual = selfValue.every(
-        (val, idx) => val === otherValue[idx]
-      );
-      if (valuesEqual) {
-        results[other] = false;
-        valid = false;
-      }
+
+  const previousValues = new Map();
+  for (let row = 0; row < longestColumn; row += 1) {
+    const rowValue = values.map((col) => col[row]);
+    // Since each column value coming from Handsontable will be a string or null
+    // this should be a safe way to produce a unique hash for the row. If there
+    // are edge cases where this doesn't work we could look at more robust
+    // solutions (e.g. https://github.com/puleos/object-hash).
+    const rowHash = rowValue.join('\u0000');
+
+    // If we have seen this hash value before it will be in the previousValues
+    // map. The key will be the row where we last saw it. This means we have a
+    // duplicate and both this row and the previous row need to be marked as
+    // in valid.
+    let rowValid = true;
+    if (previousValues.has(rowHash)) {
+      const previousRow = previousValues.get(rowHash);
+      results[previousRow] = false;
+      rowValid = false;
     }
-    results[self] = valid;
+
+    // Save this row's hash for comparison with future rows
+    previousValues.set(rowHash, row);
+    results[row] = rowValid;
   }
   return results;
 }

--- a/lib/utils/validation.js
+++ b/lib/utils/validation.js
@@ -115,19 +115,25 @@ export function validateValsAgainstVocab(delimited_string, field) {
 }
 
 /**
- * 
- * @param {Array<Array<any>>} values 
- * @return {*}
+ *
+ * @param {Array<Array<any>>} columns to validate
+ * @return {Array<boolean>}
+ *         whether each row represents a unique combination of values
  */
 export function validateUniqueValues(values) {
-  const results = []
-  const longestColumn = Math.max.apply(null, values.map((col) => col.length));
+  const results = [];
+  const longestColumn = Math.max.apply(
+    null,
+    values.map((col) => col.length)
+  );
   for (let self = 0; self < longestColumn; self += 1) {
     let valid = true;
-    const selfValue = values.map(col => col[self]);
+    const selfValue = values.map((col) => col[self]);
     for (let other = 0; other < self; other += 1) {
-      const otherValue = values.map(col => col[other]);
-      const valuesEqual = selfValue.every((val, idx) => val === otherValue[idx])
+      const otherValue = values.map((col) => col[other]);
+      const valuesEqual = selfValue.every(
+        (val, idx) => val === otherValue[idx]
+      );
       if (valuesEqual) {
         results[other] = false;
         valid = false;
@@ -135,5 +141,5 @@ export function validateUniqueValues(values) {
     }
     results[self] = valid;
   }
-  return results
+  return results;
 }

--- a/lib/utils/validation.js
+++ b/lib/utils/validation.js
@@ -113,3 +113,27 @@ export function validateValsAgainstVocab(delimited_string, field) {
   if (update_flag) return [true, value_array.join(';')];
   else return [true, false];
 }
+
+/**
+ * 
+ * @param {Array<Array<any>>} values 
+ * @return {*}
+ */
+export function validateUniqueValues(values) {
+  const results = []
+  const longestColumn = Math.max.apply(null, values.map((col) => col.length));
+  for (let self = 0; self < longestColumn; self += 1) {
+    let valid = true;
+    const selfValue = values.map(col => col[self]);
+    for (let other = 0; other < self; other += 1) {
+      const otherValue = values.map(col => col[other]);
+      const valuesEqual = selfValue.every((val, idx) => val === otherValue[idx])
+      if (valuesEqual) {
+        results[other] = false;
+        valid = false;
+      }
+    }
+    results[self] = valid;
+  }
+  return results
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-harmonizer",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "description": "A standardized spreadsheet editor and validator that can be run offline and locally",
   "repository": "git@github.com:cidgoh/DataHarmonizer.git",
   "license": "MIT",

--- a/tests/validation.test.js
+++ b/tests/validation.test.js
@@ -1,0 +1,55 @@
+import { validateUniqueValues } from '../lib/utils/validation';
+
+describe('validateUniqueValues', () => {
+  test('it should pass validation for a single column of unique values', () => {
+    let input = [[1, 2, 3]];
+    let results = validateUniqueValues(input);
+    expect(results).toEqual([true, true, true]);
+  });
+
+  test('it should fail validation for a single column of non-unique values', () => {
+    let input = [[1, 2, 1]];
+    let results = validateUniqueValues(input);
+    expect(results).toEqual([false, true, false]);
+
+    input = [[1, 2, 3, 2, 4, 2, 3]];
+    results = validateUniqueValues(input);
+    expect(results).toEqual([true, false, false, false, true, false, false]);
+  });
+
+  test('it should pass validation for multiple columns of unique pair-wise values', () => {
+    let input = [
+      [1, 2, 1],
+      [1, 2, 2],
+    ];
+    let results = validateUniqueValues(input);
+    expect(results).toEqual([true, true, true]);
+  });
+
+  test('it should fail validation for multiple columns of non-unique pair-wise values', () => {
+    let input = [
+      [1, 2, 1, 2],
+      [2, 1, 1, 1],
+    ];
+    let results = validateUniqueValues(input);
+    expect(results).toEqual([true, false, true, false]);
+
+    input = [
+      [1, 1, 1, 1, 1, 1],
+      [2, 2, 2, 2, 2, 2],
+      [3, 3, 3, 3, 3, 3],
+      [4, 4, 5, 5, 4, 6],
+    ];
+    results = validateUniqueValues(input)
+    expect(results).toEqual([false, false, false, false, false, true])
+  });
+
+  test('it should handle unequal inner array lengths', () => {
+    let input = [
+      [1, 2, 3, 4, 5],
+      [2, 3, 4, 5]
+    ]
+    let results = validateUniqueValues(input)
+    expect(results).toEqual([true, true, true, true, true])
+  })
+});

--- a/tests/validation.test.js
+++ b/tests/validation.test.js
@@ -40,16 +40,16 @@ describe('validateUniqueValues', () => {
       [3, 3, 3, 3, 3, 3],
       [4, 4, 5, 5, 4, 6],
     ];
-    results = validateUniqueValues(input)
-    expect(results).toEqual([false, false, false, false, false, true])
+    results = validateUniqueValues(input);
+    expect(results).toEqual([false, false, false, false, false, true]);
   });
 
   test('it should handle unequal inner array lengths', () => {
     let input = [
       [1, 2, 3, 4, 5],
-      [2, 3, 4, 5]
-    ]
-    let results = validateUniqueValues(input)
-    expect(results).toEqual([true, true, true, true, true])
-  })
+      [2, 3, 4, 5],
+    ];
+    let results = validateUniqueValues(input);
+    expect(results).toEqual([true, true, true, true, true]);
+  });
 });

--- a/tests/validation.test.js
+++ b/tests/validation.test.js
@@ -52,4 +52,20 @@ describe('validateUniqueValues', () => {
     let results = validateUniqueValues(input);
     expect(results).toEqual([true, true, true, true, true]);
   });
+
+  test('it should handle nulls within a column', () => {
+    let validInput = [
+      [2, 2, null,    2, 2],
+      [1, 2,    2, null, 3]
+    ];
+    let results = validateUniqueValues(validInput);
+    expect(results).toEqual([true, true, true, true, true]);
+
+    let invalidInput = [
+      [2, 2, null, null, 2],
+      [1, 2, null, null, 3],
+    ];
+    results = validateUniqueValues(invalidInput);
+    expect(results).toEqual([true, true, false, false, true]);
+  })
 });

--- a/tests/validation.test.js
+++ b/tests/validation.test.js
@@ -55,8 +55,8 @@ describe('validateUniqueValues', () => {
 
   test('it should handle nulls within a column', () => {
     let validInput = [
-      [2, 2, null,    2, 2],
-      [1, 2,    2, null, 3]
+      [2, 2, null, 2, 2],
+      [1, 2, 2, null, 3],
     ];
     let results = validateUniqueValues(validInput);
     expect(results).toEqual([true, true, true, true, true]);
@@ -67,5 +67,5 @@ describe('validateUniqueValues', () => {
     ];
     results = validateUniqueValues(invalidInput);
     expect(results).toEqual([true, true, false, false, true]);
-  })
+  });
 });


### PR DESCRIPTION
These changes add support for the [unique_keys](https://linkml.io/linkml-model/docs/unique_keys/) slot on ClassDefinition in the LinkML metamodel during validation. The core logic is implemented in a new `validateUniqueValues` function in `validation.js` with corresponding unit tests in `validation.test.js`. This utility function is also now being used to validate the uniqueness of identifier columns.

Fixes #369 