### PR TITLE
Use dynamic import for Getting Started content

### DIFF
--- a/lib/Toolbar.js
+++ b/lib/Toolbar.js
@@ -44,10 +44,12 @@ class Toolbar {
     // time. In ES bundles this dynamic import results in a separate output chunk,
     // which reduces the initial load size. There is no equivalent in UMD bundles,
     // in which case the content gets inlined.
-    $('#getting-started-modal').on('show.bs.modal', async function() {
+    $('#getting-started-modal').on('show.bs.modal', async function () {
       const modalContainer = $('#getting-started-carousel-container');
       if (!modalContainer.html()) {
-        const { getGettingStartedMarkup } = (await import('./toolbarGettingStarted'));
+        const { getGettingStartedMarkup } = await import(
+          './toolbarGettingStarted'
+        );
         modalContainer.html(getGettingStartedMarkup());
       }
     });

--- a/lib/Toolbar.js
+++ b/lib/Toolbar.js
@@ -8,7 +8,6 @@ import '@selectize/selectize/dist/css/selectize.bootstrap4.css';
 import { exportFile, exportJsonFile } from './utils/files';
 
 import template from './toolbar.html';
-import { getGettingStartedMarkup } from './toolbarGettingStarted';
 
 import './toolbar.css';
 
@@ -40,7 +39,18 @@ class Toolbar {
     this.$selectTemplate = $('#select-template');
 
     $('#version-dropdown-item').text('version ' + VERSION);
-    $('#getting-started-carousel-container').html(getGettingStartedMarkup());
+
+    // Defer loading the Getting Started content until it is used for the first
+    // time. In ES bundles this dynamic import results in a separate output chunk,
+    // which reduces the initial load size. There is no equivalent in UMD bundles,
+    // in which case the content gets inlined.
+    $('#getting-started-modal').on('show.bs.modal', async function() {
+      const modalContainer = $('#getting-started-carousel-container');
+      if (!modalContainer.html()) {
+        const { getGettingStartedMarkup } = (await import('./toolbarGettingStarted'));
+        modalContainer.html(getGettingStartedMarkup());
+      }
+    });
 
     // Select menu for available templates. If the `templatePath` option was
     // provided attempt to use that one. If not the first item in the menu

--- a/lib/rollup.config.js
+++ b/lib/rollup.config.js
@@ -24,6 +24,7 @@ export default {
       globals: {
         jquery: '$',
       },
+      inlineDynamicImports: true,
     },
   ],
   external: ['jquery'],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-harmonizer",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "description": "A standardized spreadsheet editor and validator that can be run offline and locally",
   "repository": "git@github.com:cidgoh/DataHarmonizer.git",
   "license": "MIT",


### PR DESCRIPTION
The Getting Started carousel content was already included in a separate module (`lib/toolbarGettingStarted.js`) because I was hoping that would make it [tree-shakable](https://developer.mozilla.org/en-US/docs/Glossary/Tree_shaking) -- i.e. that content could be omitted from downstream client bundles if they weren't `import`-ing the `Toolbar` component. Unfortunately, it turns out that's _not_ the case because the `Toolbar` module itself cannot be marked as [side-effect free](https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free).

Here is an alternative approach where the `lib/toolbarGettingStarted` module is [dynamically imported](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import) the first time the Getting Started carousel is opened. This results in a separate, dynamically-loaded output chunk in the ES build of the library. The UMD build doesn't support such constructs, so it still needs to be inlined there. But I would expect most downstream clients to be using the ES build anyway (NMDC, in particular, does).