### PR TITLE
Add columnHelpEntries constructor option

### DIFF
--- a/lib/DataHarmonizer.js
+++ b/lib/DataHarmonizer.js
@@ -56,7 +56,13 @@ class DataHarmonizer {
     this.loadingScreenRoot = options.loadingScreenRoot || this.root;
     this.modalsRoot = options.modalsRoot || document.querySelector('body');
     this.field_settings = options.fieldSettings || {};
-    this.columnHelpEntries = options.columnHelpEntries || ['column', 'description', 'guidance', 'examples', 'menus']
+    this.columnHelpEntries = options.columnHelpEntries || [
+      'column',
+      'description',
+      'guidance',
+      'examples',
+      'menus',
+    ];
     this.self = this;
 
     this.injectLoadingScreen();
@@ -634,27 +640,29 @@ class DataHarmonizer {
     let row_html = '';
     for (const section of this.template) {
       row_html += `<tr class="section">
-      <td colspan="${this.columnHelpEntries.length}"><h3>${section.title || section.name}</h3></td>
+      <td colspan="${this.columnHelpEntries.length}"><h3>${
+        section.title || section.name
+      }</h3></td>
       </tr>
       `;
       for (const slot of section.children) {
         const slot_dict = this.getCommentDict(slot);
 
-        row_html += '<tr>'
+        row_html += '<tr>';
         if (this.columnHelpEntries.includes('column')) {
-          row_html += `<td class="label">${slot_dict.title}</td>`
+          row_html += `<td class="label">${slot_dict.title}</td>`;
         }
         if (this.columnHelpEntries.includes('description')) {
-          row_html += `<td>${slot_dict.description}</td>`
+          row_html += `<td>${slot_dict.description}</td>`;
         }
         if (this.columnHelpEntries.includes('guidance')) {
-          row_html += `<td>${slot_dict.guidance}</td>`
+          row_html += `<td>${slot_dict.guidance}</td>`;
         }
         if (this.columnHelpEntries.includes('examples')) {
-          row_html += `<td>${slot_dict.examples}</td>`
+          row_html += `<td>${slot_dict.examples}</td>`;
         }
         if (this.columnHelpEntries.includes('menus')) {
-          row_html += ` <td>${slot_dict.sources || ''}</td>`
+          row_html += ` <td>${slot_dict.sources || ''}</td>`;
         }
         row_html += '</tr>';
       }
@@ -686,11 +694,31 @@ class DataHarmonizer {
     <table>
     <thead>
     <tr>
-    ${this.columnHelpEntries.includes('column') ? '<th class="label">Column</th>' : ''}
-    ${this.columnHelpEntries.includes('description') ? '<th class="description">Description</th>' : ''}
-    ${this.columnHelpEntries.includes('guidance') ? '<th class="guidance">Guidance</th>' : ''}
-    ${this.columnHelpEntries.includes('examples') ? '<th class="example">Examples</th>' : ''}
-    ${this.columnHelpEntries.includes('menus') ? '<th class="data_status">Menus</th>' : ''}
+    ${
+      this.columnHelpEntries.includes('column')
+        ? '<th class="label">Column</th>'
+        : ''
+    }
+    ${
+      this.columnHelpEntries.includes('description')
+        ? '<th class="description">Description</th>'
+        : ''
+    }
+    ${
+      this.columnHelpEntries.includes('guidance')
+        ? '<th class="guidance">Guidance</th>'
+        : ''
+    }
+    ${
+      this.columnHelpEntries.includes('examples')
+        ? '<th class="example">Examples</th>'
+        : ''
+    }
+    ${
+      this.columnHelpEntries.includes('menus')
+        ? '<th class="data_status">Menus</th>'
+        : ''
+    }
     </tr>
     </thead>
     <tbody>
@@ -1234,7 +1262,7 @@ class DataHarmonizer {
     let slot_dict = this.getCommentDict(field);
 
     let ret = '';
-    
+
     if (this.columnHelpEntries.includes('column')) {
       ret += `<p><strong>Column</strong>: ${field.title || field.name}</p>`;
     }

--- a/lib/DataHarmonizer.js
+++ b/lib/DataHarmonizer.js
@@ -56,6 +56,7 @@ class DataHarmonizer {
     this.loadingScreenRoot = options.loadingScreenRoot || this.root;
     this.modalsRoot = options.modalsRoot || document.querySelector('body');
     this.field_settings = options.fieldSettings || {};
+    this.columnHelpEntries = options.columnHelpEntries || ['column', 'description', 'guidance', 'examples', 'menus']
     this.self = this;
 
     this.injectLoadingScreen();
@@ -633,20 +634,29 @@ class DataHarmonizer {
     let row_html = '';
     for (const section of this.template) {
       row_html += `<tr class="section">
-      <td colspan="5"><h3>${section.title || section.name}</h3></td>
+      <td colspan="${this.columnHelpEntries.length}"><h3>${section.title || section.name}</h3></td>
       </tr>
       `;
       for (const slot of section.children) {
         const slot_dict = this.getCommentDict(slot);
 
-        row_html += `<tr>
-        <td class="label">${slot_dict.title}</td>
-        <td>${slot_dict.description}</td>
-        <td>${slot_dict.guidance}</td>
-        <td>${slot_dict.examples}</td>
-        <td>${slot_dict.sources || ''}</td>
-        </tr>
-        `;
+        row_html += '<tr>'
+        if (this.columnHelpEntries.includes('column')) {
+          row_html += `<td class="label">${slot_dict.title}</td>`
+        }
+        if (this.columnHelpEntries.includes('description')) {
+          row_html += `<td>${slot_dict.description}</td>`
+        }
+        if (this.columnHelpEntries.includes('guidance')) {
+          row_html += `<td>${slot_dict.guidance}</td>`
+        }
+        if (this.columnHelpEntries.includes('examples')) {
+          row_html += `<td>${slot_dict.examples}</td>`
+        }
+        if (this.columnHelpEntries.includes('menus')) {
+          row_html += ` <td>${slot_dict.sources || ''}</td>`
+        }
+        row_html += '</tr>';
       }
     }
 
@@ -676,11 +686,11 @@ class DataHarmonizer {
     <table>
     <thead>
     <tr>
-    <th class="label">Field</th>
-    <th class="description">Description</th>
-    <th class="guidance">Guidance</th>
-    <th class="example">Examples</th>
-    <th class="data_status">Menus</th>
+    ${this.columnHelpEntries.includes('column') ? '<th class="label">Column</th>' : ''}
+    ${this.columnHelpEntries.includes('description') ? '<th class="description">Description</th>' : ''}
+    ${this.columnHelpEntries.includes('guidance') ? '<th class="guidance">Guidance</th>' : ''}
+    ${this.columnHelpEntries.includes('examples') ? '<th class="example">Examples</th>' : ''}
+    ${this.columnHelpEntries.includes('menus') ? '<th class="data_status">Menus</th>' : ''}
     </tr>
     </thead>
     <tbody>
@@ -1223,23 +1233,28 @@ class DataHarmonizer {
   getComment(field) {
     let slot_dict = this.getCommentDict(field);
 
-    let ret = `<p><strong>Label</strong>: ${field.title}</p>`;
-    ret += `<p><strong>Name</strong>: ${field.name}</p>`;
+    let ret = '';
+    
+    if (this.columnHelpEntries.includes('column')) {
+      ret += `<p><strong>Column</strong>: ${field.title || field.name}</p>`;
+    }
 
-    if (field.description) {
+    if (field.description && this.columnHelpEntries.includes('description')) {
       ret += `<p><strong>Description</strong>: ${field.description}</p>`;
     }
 
-    if (slot_dict.guidance) {
+    if (slot_dict.guidance && this.columnHelpEntries.includes('guidance')) {
       ret += `<p><strong>Guidance</strong>: ${slot_dict.guidance}</p>`;
     }
 
-    if (slot_dict.examples) {
+    if (slot_dict.examples && this.columnHelpEntries.includes('examples')) {
       ret += `<p><strong>Examples</strong>: </p>${slot_dict.examples}`;
     }
-    if (slot_dict.sources) {
+
+    if (slot_dict.sources && this.columnHelpEntries.includes('menus')) {
       ret += `<p><strong>Menus</strong>: </p>${slot_dict.sources}`;
     }
+
     return ret;
   }
 


### PR DESCRIPTION
Related to: https://github.com/microbiomedata/issues/issues/88

This introduces a `columnHelpEntries` field that will be recognized in the options object passed to the `DataHarmonizer` constructor. It is a list of which fields should be included in the column help displays -- both the popup you get when double-clicking the column header and the complete reference guide. The default leaves the current help displays unchanged. 