### PR TITLE
Add help sidebar component

### DIFF
--- a/lib/DataHarmonizer.js
+++ b/lib/DataHarmonizer.js
@@ -59,6 +59,10 @@ class DataHarmonizer {
     this.loadingScreenRoot = options.loadingScreenRoot || this.root;
     this.modalsRoot = options.modalsRoot || document.querySelector('body');
     this.field_settings = options.fieldSettings || {};
+    this.helpSidebarOptions = Object.assign(
+      { enabled: true },
+      options.helpSidebar || {}
+    );
     this.columnHelpEntries = options.columnHelpEntries || [
       'column',
       'description',
@@ -69,13 +73,18 @@ class DataHarmonizer {
     this.self = this;
 
     // Use help sidebar by default unless turned off by client
-    if (
-      options.includeHelpSidebar === undefined ||
-      options.includeHelpSidebar
-    ) {
-      this.helpSidebar = new HelpSidebar(this.root, {
-        onToggle: () => this.hot.render(),
-      });
+    if (this.helpSidebarOptions.enabled) {
+      const opts = Object.assign({}, this.helpSidebarOptions);
+      opts.onToggle = (open) => {
+        // always do a HOT rerender on toggle in addition to anything client-specified
+        if (this.hot) {
+          this.hot.render();
+        }
+        if (typeof this.helpSidebarOptions.onToggle === 'function') {
+          this.helpSidebarOptions.onToggle(open);
+        }
+      };
+      this.helpSidebar = new HelpSidebar(this.root, opts);
     }
 
     this.injectLoadingScreen();

--- a/lib/DataHarmonizer.js
+++ b/lib/DataHarmonizer.js
@@ -31,6 +31,8 @@ import specifyHeadersModal from './specifyHeadersModal.html';
 import unmappedHeadersModal from './unmappedHeadersModal.html';
 import fieldDescriptionsModal from './fieldDescriptionsModal.html';
 
+import HelpSidebar from './HelpSidebar';
+
 import pkg from '../package.json';
 const VERSION = pkg.version;
 const VERSION_TEXT = 'DataHarmonizer v' + VERSION;
@@ -52,6 +54,7 @@ class DataHarmonizer {
 
   constructor(root, options = {}) {
     this.root = root;
+    this.hotRoot = options.hotRoot || $('<div>').appendTo(this.root)[0];
     this.schema = options.schema;
     this.loadingScreenRoot = options.loadingScreenRoot || this.root;
     this.modalsRoot = options.modalsRoot || document.querySelector('body');
@@ -64,6 +67,12 @@ class DataHarmonizer {
       'menus',
     ];
     this.self = this;
+
+    this.helpSidebar = new HelpSidebar(this.root, {
+      onToggle: () => {
+        this.hot.render();
+      }
+    });
 
     this.injectLoadingScreen();
 
@@ -471,6 +480,9 @@ class DataHarmonizer {
         },
         afterSelection: (row, column, row2, column2) => {
           self.current_selection = [row, column, row2, column2];
+          const field = self.getFields()[column];
+          const helpContent = self.getComment(field);
+          self.helpSidebar.setContent(helpContent);
         },
         afterRender: () => {
           // Bit of a hackey way to RESTORE classes to secondary headers. They are
@@ -497,7 +509,7 @@ class DataHarmonizer {
         },
       };
 
-      this.hot = new Handsontable(this.root, hot_settings);
+      this.hot = new Handsontable(this.hotRoot, hot_settings);
 
       this.enableMultiSelection();
     } else {

--- a/lib/DataHarmonizer.js
+++ b/lib/DataHarmonizer.js
@@ -69,7 +69,10 @@ class DataHarmonizer {
     this.self = this;
 
     // Use help sidebar by default unless turned off by client
-    if (options.includeHelpSidebar === undefined || options.includeHelpSidebar) {
+    if (
+      options.includeHelpSidebar === undefined ||
+      options.includeHelpSidebar
+    ) {
       this.helpSidebar = new HelpSidebar(this.root, {
         onToggle: () => this.hot.render(),
       });

--- a/lib/DataHarmonizer.js
+++ b/lib/DataHarmonizer.js
@@ -68,11 +68,12 @@ class DataHarmonizer {
     ];
     this.self = this;
 
-    this.helpSidebar = new HelpSidebar(this.root, {
-      onToggle: () => {
-        this.hot.render();
-      }
-    });
+    // Use help sidebar by default unless turned off by client
+    if (options.includeHelpSidebar === undefined || options.includeHelpSidebar) {
+      this.helpSidebar = new HelpSidebar(this.root, {
+        onToggle: () => this.hot.render(),
+      });
+    }
 
     this.injectLoadingScreen();
 
@@ -480,9 +481,11 @@ class DataHarmonizer {
         },
         afterSelection: (row, column, row2, column2) => {
           self.current_selection = [row, column, row2, column2];
-          const field = self.getFields()[column];
-          const helpContent = self.getComment(field);
-          self.helpSidebar.setContent(helpContent);
+          if (this.helpSidebar) {
+            const field = self.getFields()[column];
+            const helpContent = self.getComment(field);
+            self.helpSidebar.setContent(helpContent);
+          }
         },
         afterRender: () => {
           // Bit of a hackey way to RESTORE classes to secondary headers. They are

--- a/lib/HelpSidebar.css
+++ b/lib/HelpSidebar.css
@@ -1,0 +1,31 @@
+.help-sidebar {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    background-color: white;
+    transition-property: right;
+    transition-timing-function: ease;
+    border-left: 1px solid #ddd;
+}
+
+.help-sidebar__toggler {
+    position: absolute;
+    top: 0;
+    transform: translateX(-100%);
+    z-index: 200;
+    border: 1px solid #ddd;
+    border-right-width: 0;
+    background-color: white;
+}
+
+.help-sidebar__content {
+    height: 100%;
+    overflow-x: hidden;
+    overflow-y: auto;
+    margin: 8px
+}
+
+.help-sidebar__placeholder {
+    color: #808080;
+    font-style: italic;
+}

--- a/lib/HelpSidebar.css
+++ b/lib/HelpSidebar.css
@@ -1,31 +1,31 @@
 .help-sidebar {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    background-color: white;
-    transition-property: right;
-    transition-timing-function: ease;
-    border-left: 1px solid #ddd;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  background-color: white;
+  transition-property: right;
+  transition-timing-function: ease;
+  border-left: 1px solid #ddd;
 }
 
 .help-sidebar__toggler {
-    position: absolute;
-    top: 0;
-    transform: translateX(-100%);
-    z-index: 200;
-    border: 1px solid #ddd;
-    border-right-width: 0;
-    background-color: white;
+  position: absolute;
+  top: 0;
+  transform: translateX(-100%);
+  z-index: 200;
+  border: 1px solid #ddd;
+  border-right-width: 0;
+  background-color: white;
 }
 
 .help-sidebar__content {
-    height: 100%;
-    overflow-x: hidden;
-    overflow-y: auto;
-    margin: 8px
+  height: 100%;
+  overflow-x: hidden;
+  overflow-y: auto;
+  margin: 8px;
 }
 
 .help-sidebar__placeholder {
-    color: #808080;
-    font-style: italic;
+  color: #808080;
+  font-style: italic;
 }

--- a/lib/HelpSidebar.js
+++ b/lib/HelpSidebar.js
@@ -1,0 +1,107 @@
+import $ from 'jquery';
+import './HelpSidebar.css'
+
+const DEFAULT_OPTIONS = {
+  width: 300,
+  toggleTransitionDuration: 300,
+  onToggle: null,
+  title: 'Column Help',
+  placeholder: 'Select a cell to get help for that column.',
+  closedToggleLabel: '?',
+  openedToggleLabel: '&times;',
+};
+
+class HelpSidebar {
+  constructor(root, options) {
+    this.root = $(root);
+    this.isOpen = false;
+
+    this.options = Object.assign({}, DEFAULT_OPTIONS, options);
+    if (this.options.openedToggleLabel == null) {
+      this.options.openedToggleLabel = this.options.closedToggleLabel;
+    }
+
+    this._init();
+  }
+
+  _getWidth() {
+    return this.isOpen ? 0 : this.options.width;
+  }
+
+  _getTogglerLabel() {
+    return this.isOpen
+      ? this.options.openedToggleLabel
+      : this.options.closedToggleLabel;
+  }
+
+  _setOpen(isOpen) {
+    this.isOpen = isOpen;
+    this.sidebar.css('right', -this._getWidth());
+    this.root.css('padding-right', this.options.width - this._getWidth());
+    this.toggler.toggleClass('open', this.isOpen).html(this._getTogglerLabel());
+    if (typeof this.options.onToggle === 'function') {
+      setTimeout(
+        () => this.options.onToggle(this.isOpen),
+        this.options.toggleTransitionDuration
+      );
+    }
+  }
+
+  _handleTogglerClick(event) {
+    event.preventDefault();
+    this.toggle();
+  }
+
+  _init() {
+    this.root.css({
+      position: 'relative',
+      overflow: 'hidden',
+    });
+
+    this.sidebar = $(`<div class="help-sidebar"></div>`)
+      .css({
+        width: this.options.width,
+        right: -this._getWidth(),
+        'transition-duration': this.options.toggleTransitionDuration + 'ms',
+      })
+      .appendTo(this.root);
+
+    this.content = $(
+      `<div class="help-sidebar__content">
+        <h4 class="help-sidebar__title">${this.options.title}</h4>
+      </div>`
+    ).appendTo(this.sidebar);
+
+    this.contentInner = $(
+      `<div class="help-sidebar__content-inner">
+        <p class="help-sidebar__placeholder">
+          ${this.options.placeholder}
+        </p>
+      </div>`
+    ).appendTo(this.content);
+
+    this.toggler = $(
+      `<button class="help-sidebar__toggler">${this._getTogglerLabel()}</button>`
+    ).appendTo(this.sidebar);
+
+    this.toggler.on('click', this._handleTogglerClick.bind(this));
+  }
+
+  setContent(content) {
+    this.contentInner.html(content);
+  }
+
+  toggle() {
+    this._setOpen(!this.isOpen);
+  }
+
+  open() {
+    this._setOpen(true);
+  }
+
+  close() {
+    this._setOpen(false);
+  }
+}
+
+export default HelpSidebar;

--- a/lib/HelpSidebar.js
+++ b/lib/HelpSidebar.js
@@ -1,5 +1,5 @@
 import $ from 'jquery';
-import './HelpSidebar.css'
+import './HelpSidebar.css';
 
 const DEFAULT_OPTIONS = {
   width: 300,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-harmonizer",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "description": "A standardized spreadsheet editor and validator that can be run offline and locally",
   "repository": "git@github.com:cidgoh/DataHarmonizer.git",
   "license": "MIT",

--- a/web/index.css
+++ b/web/index.css
@@ -7,9 +7,6 @@ body {
   overscroll-behavior: contain;
 }
 
-.data-harmonizer-grid {
-  overflow: hidden;
-}
 .data-harmonizer-grid .secondary-header-cell:hover {
   cursor: pointer;
 }


### PR DESCRIPTION
This adds a `HelpSidebar` component. Since I'm assuming most clients will want to use it by default I'm having `DataHarmonizer` instances create and configure a `HelpSidebar` instance (as opposed to leaving that up to the client application). 

The help sidebar can be disabled by providing the following configuration when constructing the `DataHarmonizer` instance:

```js
new DataHarmonizer(dhRoot, {
  helpSidebar: {
    enabled: false
  }
})
```

All other configuration in the `helpSidebar` option is passed to the `HelpSidebar` constructor (see defaults [here](https://github.com/cidgoh/DataHarmonizer/pull/393/files#diff-29b30a4cac12eec818921fb55c1e0e98a8351c3fd311e392304ba362bd2bd497R4-R12)). For example to change the width of the sidebar:

```js
new DataHarmonizer(dhRoot, {
  helpSidebar: {
    width: 200
  }
})
```

Fixes #392 