### PR TITLE
Add ability to import and export data in container object format

### DIFF
--- a/lib/DataHarmonizer.js
+++ b/lib/DataHarmonizer.js
@@ -1543,6 +1543,23 @@ class DataHarmonizer {
    */
   loadDataObjects(data) {
     const fields = this.getFields();
+    if (typeof data === 'object' && !Array.isArray(data) && data !== null) {
+      // An object was provided, so try to pick out the grid data from
+      // one of it's fields.
+      const inferredIndexSlot = this.getInferredIndexSlot();
+      if (inferredIndexSlot) {
+        data = data[inferredIndexSlot];
+      } else {
+        const dataKeys = Object.keys(data);
+        if (dataKeys.length === 1) {
+          data = data[dataKeys[0]];
+        }
+      }
+    }
+    if (!Array.isArray(data)) {
+      console.warn('Unable to get grid data from input');
+      return;
+    }
     const listData = data.map((row) =>
       dataObjectToArray(row, fields, {
         serializedDateFormat: this.dateExportBehavior,

--- a/lib/DataHarmonizer.js
+++ b/lib/DataHarmonizer.js
@@ -1456,22 +1456,36 @@ class DataHarmonizer {
    * If parsing fails the original string value is used instead. This behavior
    * can be changed using the `options` argument.
    *
+   * The list of objects can optionally be wrapped in a top-level object based
+   * on the `indexSlot` option.
+   *
    * @param {Object} options An object with any of the following keys:
    *   - parseFailureBehavior: `KEEP_ORIGINAL` (default) | `REMOVE` | `THROW_ERROR`
    *     controls how values which are not parsable according to the column's datatype are
    *     handled. By default the original string value is retained. If this option is `REMOVE`
    *     the unparsable value is removed entirely. If this option is `THROW_ERROR`, an error
    *     is thrown when the first unparsable value is encountered.
-   * @return {Array<Object>}
+   *   - indexSlot: boolean | string. If a string is provided the output will be an object
+   *     with one key. The key is provided string. The value of the key is the array of objects
+   *     representing the grid data. If `false` is provided (the default), the output will
+   *     be the array of objects representing the grid data. If `true` is provided, an index
+   *     slot will be inferred from the schema and the current template by identifying
+   *     its a tree_root (https://w3id.org/linkml/tree_root) class and inspecting the ranges of
+   *     attributes. If that inference fails, `fallbackIndexSlot` will be used instead.
+   *   - fallbackIndexSlot: A string that will be used as the index slot name if indexSlot is
+   *     `true` and the inference process fails to identify a unique index slot candidate.
+   * @return {(Object|Array<Object>)}
    */
   getDataObjects(options = {}) {
-    const { parseFailureBehavior } = {
+    const { parseFailureBehavior, indexSlot, fallbackIndexSlot } = {
       parseFailureBehavior: KEEP_ORIGINAL,
+      indexSlot: false,
+      fallbackIndexSlot: 'rows',
       ...options,
     };
     const listData = this.hot.getData();
     const fields = this.getFields();
-    return listData
+    const arrayOfObjects = listData
       .filter((row) => row.some((cell) => cell !== '' && cell != null))
       .map((row) =>
         dataArrayToObject(row, fields, {
@@ -1482,6 +1496,43 @@ class DataHarmonizer {
           timeFormat: this.timeFormat,
         })
       );
+    if (typeof indexSlot === 'string') {
+      return {
+        [indexSlot]: arrayOfObjects,
+      };
+    } else if (indexSlot === true) {
+      let inferredIndexSlot = this.getInferredIndexSlot();
+      if (!inferredIndexSlot) {
+        inferredIndexSlot = fallbackIndexSlot;
+      }
+      return {
+        [inferredIndexSlot]: arrayOfObjects,
+      };
+    } else {
+      return arrayOfObjects;
+    }
+  }
+
+  getInferredIndexSlot() {
+    const classes = Object.values(this.schema.classes);
+    const treeRootClass = classes.find((cls) => cls.tree_root);
+    if (!treeRootClass) {
+      console.warn(
+        `While getting inferred index slot, could not find tree_root class.`
+      );
+      return;
+    }
+    const treeRootAttrs = Object.values(treeRootClass.attributes);
+    const index_attrs = treeRootAttrs.filter(
+      (attr) => attr.range === this.template_name
+    );
+    if (!index_attrs || index_attrs.length !== 1) {
+      console.warn(
+        `While getting inferred index slot, could not find single slot with range ${this.template_name} on tree_root class ${treeRootClass.name}.`
+      );
+      return;
+    }
+    return index_attrs[0].name;
   }
 
   /**

--- a/lib/Toolbar.js
+++ b/lib/Toolbar.js
@@ -116,12 +116,39 @@ class Toolbar {
       }
     });
 
+    $('#file-ext-save-as-select').on('change', (evt) => {
+      const ext = evt.target.value;
+      if (ext === 'json') {
+        $('#save-as-json-options').removeClass('d-none');
+        const inferredIndexSlot = dh.getInferredIndexSlot();
+        $('#save-as-json-index-key').val(inferredIndexSlot);
+      } else {
+        $('#save-as-json-options').addClass('d-none');
+      }
+    });
+
+    $('#save-as-json-use-index').on('change', (evt) => {
+      const checked = evt.target.checked;
+      $('#save-as-json-index-key').prop('disabled', !checked);
+    });
+
     $('#save-as-confirm-btn').click(() => {
       try {
         const baseName = $('#base-name-save-as-input').val();
         const ext = $('#file-ext-save-as-select').val();
         if (ext == 'json') {
-          let data = dh.getDataObjects();
+          let indexSlot = false;
+          if ($('#save-as-json-use-index').is(':checked')) {
+            const indexSlotInput = $('#save-as-json-index-key').val();
+            if (indexSlotInput) {
+              indexSlot = indexSlotInput;
+            } else {
+              indexSlot = true;
+            }
+          }
+          let data = dh.getDataObjects({
+            indexSlot,
+          });
           dh.runBehindLoadingScreen(exportJsonFile, [data, baseName, ext]);
         } else {
           let matrix = [...dh.getFlatHeaders(), ...dh.getTrimmedData()];

--- a/lib/toolbar.html
+++ b/lib/toolbar.html
@@ -346,6 +346,32 @@
                 </div>
               </div>
             </div>
+            <div
+              class="form-row align-items-center d-none"
+              id="save-as-json-options"
+            >
+              <div class="col-auto">
+                <div class="form-check mt-2 mr-2">
+                  <input
+                    class="form-check-input"
+                    type="checkbox"
+                    id="save-as-json-use-index"
+                  />
+                  <label class="form-check-label" for="save-as-json-use-index">
+                    Save as object with index key
+                  </label>
+                </div>
+              </div>
+              <div class="col-4">
+                <label class="sr-only" for="save-as-json-index-key">Name</label>
+                <input
+                  type="text"
+                  class="form-control mt-2"
+                  id="save-as-json-index-key"
+                  disabled
+                />
+              </div>
+            </div>
             <div class="row mt-3">
               <div class="col-2 col-sm-6"></div>
               <div class="col d-flex justify-content-end">


### PR DESCRIPTION
This resolves #390.

Currently, the `getDataObjects` and `loadDataObjects` methods provide and accept arrays of objects. For various reasons, when working in the LinkML ecosystem we often want those arrays to be wrapped in a top-level or "container" object. That is:

```json
{
  "items": [
    . . .
  ]
}
```

As opposed to:

```json
[
  . . .
]
```

In the above example, `items` would be referred to as the "index slot" of the container object. In many cases the name of the index slot can be inferred.

These changes allow `getDataObjects` and `loadDataObjects` to work with both arrays (as they currently do) and arrays wrapped in a container object.

On the exporting side, I've added some interface elements to the Toolbar's "Save As" menu which allows you to choose whether you want to save as an array or an object and, for objects, provide an index slot name (the inferred one will be populated if possible). These values are then passed to new options on the `getDataObjects` method.

On the loading side, `loadDataObjects` now detects if an object is provided and if so attempts pick the actual grid data out of the right key. 

cc: @turbomam 