### PR TITLE
Let required attribute to take precedence over recommended for header style

### DIFF
--- a/lib/DataHarmonizer.js
+++ b/lib/DataHarmonizer.js
@@ -552,8 +552,8 @@ class DataHarmonizer {
             $(TH).addClass('secondary-header-cell');
             if (column > -1) {
               const field = self.fields[column];
-              if (field.recommended) $(TH).addClass('recommended');
-              else if (field.required) $(TH).addClass('required');
+              if (field.required) $(TH).addClass('required');
+              else if (field.recommended) $(TH).addClass('recommended');
             }
           }
         },


### PR DESCRIPTION
I was doing a test integration of the latest unreleased DataHarmonizer changes into NMDC, and I noticed this minor issue. In our schema we have a number of slots that have both `required: true` and `recommended: true`. It's a bit of a quirk of how we build our schema that both of those get set. Regardless, it seems reasonable to me to present these with the "required" column header style, rather than the "recommended" style.