### PR TITLE
Use shared string table when exporting xls

### DIFF
--- a/lib/utils/files.js
+++ b/lib/utils/files.js
@@ -62,7 +62,11 @@ export function exportFile(matrix, baseName, ext) {
       writeFile(workbook, `${baseName}.xlsx`);
       break;
     case 'xls':
-      writeFile(workbook, `${baseName}.xls`);
+      writeFile(workbook, `${baseName}.xls`, {
+        bookType: 'biff8',
+        type: 'file',
+        bookSST: true,
+      });
       break;
     case 'tsv':
       writeFile(workbook, `${baseName}.tsv`, {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-harmonizer",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "A standardized spreadsheet editor and validator that can be run offline and locally",
   "repository": "git@github.com:cidgoh/DataHarmonizer.git",
   "license": "MIT",


### PR DESCRIPTION
Resolves #442 
This removes cell cap of 255 chars for xls exports