### PR TITLE
Show semantic id for each slot 

### DIFF
--- a/lib/DataHarmonizer.js
+++ b/lib/DataHarmonizer.js
@@ -1930,8 +1930,7 @@ class DataHarmonizer {
       )}</strong>: ${field.title || field.name}</p>`;
     }
 
-    // Requires markup treatment of URLS.  Issue: this is getting rendered
-    // wrong.
+    // Requires markup treatment of URLS.
     const slot_uri = this.renderSemanticID(field.slot_uri);
     if (field.slot_uri && this.columnHelpEntries.includes('slot_uri')) {
       ret += `<p><strong data-i18n="help-sidebar__column">${i18next.t(

--- a/lib/DataHarmonizer.js
+++ b/lib/DataHarmonizer.js
@@ -1897,7 +1897,7 @@ class DataHarmonizer {
 
     // Requires markup treatment of URLS.  Issue: this is getting rendered
     // wrong.
-    const slot_uri = this.renderSemanticID(field.slot_uri, true);
+    const slot_uri = this.renderSemanticID(field.slot_uri);
     if (field.slot_uri && this.columnHelpEntries.includes('slot_uri')) {
       ret += `<p><strong data-i18n="help-sidebar__column">${i18next.t(
         'help-sidebar__slot_uri'

--- a/lib/DataHarmonizer.js
+++ b/lib/DataHarmonizer.js
@@ -1129,11 +1129,34 @@ class DataHarmonizer {
           row_html += `<td>${slot_dict.examples}</td>`;
         }
         if (this.columnHelpEntries.includes('menus')) {
-          row_html += ` <td>${slot_dict.sources || ''}</td>`;
+          row_html += ` <td>${slot_dict.menus || ''}</td>`;
         }
         row_html += '</tr>';
       }
     }
+
+    // Note this may include more enumerations than exist in a given template.
+    let enum_html = ``;
+    for (const key of Object.keys(this.schema.enums).sort()) {
+      const enumeration = this.schema.enums[key];
+      let title = enumeration.title != enumeration.name ? enumeration.title : '';
+      enum_html += `<tr class="section">
+      <td colspan="2" id="${enumeration.name}">${enumeration.name}</td>
+      <td colspan="2">(${title})<br/>${this.renderSemanticID(enumeration.enum_uri)}</td>
+      </tr>`;
+
+      for (const item_key in enumeration.permissible_values) {
+        const item = enumeration.permissible_values[item_key];
+        let text = item.text != item_key ? item.text : '';
+        enum_html += `<tr>
+        <td>${this.renderSemanticID(item.meaning)}</td>
+        <td>${item_key}</td>
+        <td>${text}</td>
+        <td></td>
+        </tr>`;
+      }
+    }
+
 
     var win = window.open(
       '',
@@ -1195,7 +1218,19 @@ class DataHarmonizer {
     </tbody>
     </table>
     </div>
-    </body>
+    
+        <div>
+          <table>
+            <thead>
+              <tr class="section">
+                <td colspan="4"><h3>${i18next.t('help-picklists')}</h3>
+                </td>
+              </tr>
+            </thead>
+            <tbody>${enum_html}</tbody>
+          </table>
+        </div>
+      </body>
     </html>
     `;
     return false;
@@ -1948,6 +1983,7 @@ class DataHarmonizer {
       guidance: '',
       examples: '',
       sources: '',
+      menus: ''
     };
 
     let guidance = [];
@@ -1992,7 +2028,13 @@ class DataHarmonizer {
       guidance.push(i18next.t('reference_guide_msg_unique_record'));
     }
     if (field.sources && field.sources.length) {
-      let sources = [];
+      let menus = [];
+      for (const item of field.sources) {
+        menus.push('<a href="#'+ item + '" target="_self">' + item +'</a>');
+      }
+      guide.menus = '<ul><li>' + menus.join('</li><li>') + '</li></ul>';
+      /*
+      // List null value menu items directly
       for (const [, item] of Object.entries(field.sources)) {
         // List null value menu items directly
         if (item === 'NullValueMenu') {
@@ -2004,7 +2046,8 @@ class DataHarmonizer {
           sources.push(item);
         }
       }
-      guide.sources = '<ul><li>' + sources.join('</li>\n<li>') + '</li></ul>';
+      */
+      guide.sources = '<ul><li>' + field.sources.join('</li><li>') + '</li></ul>';
     }
     if (field.multivalued) {
       guidance.push(i18next.t('reference_guide_msg_more_than_one_selection'));
@@ -2035,9 +2078,9 @@ class DataHarmonizer {
 
         if (first_item === true) {
           first_item = false;
-          examples += '<ul><li>' + i18next.t(item.value) + '</li>\n';
+          examples += '<ul><li>' + i18next.t(item.value) + '</li>';
         } else {
-          examples += '<li>' + i18next.t(item.value) + '</li>\n';
+          examples += '<li>' + i18next.t(item.value) + '</li>';
         }
       }
       guide.examples = examples + '</ul>';

--- a/lib/DataHarmonizer.js
+++ b/lib/DataHarmonizer.js
@@ -125,6 +125,7 @@ class DataHarmonizer {
     );
     this.columnHelpEntries = options.columnHelpEntries || [
       'column',
+      'slot_uri',
       'description',
       'guidance',
       'examples',
@@ -176,7 +177,7 @@ class DataHarmonizer {
         (field) => field.title === field_reference
       );
       $('#field-description-text').html(
-        urlToClickableAnchor(this.getComment(field))
+        this.getComment(field)
       );
       $('#field-description-modal').modal('show');
     });
@@ -1037,6 +1038,30 @@ class DataHarmonizer {
     hotInstance.render(); // Render the table to apply changes
   }
 
+  renderSemanticID(curieOrURI, as_markup = false) {
+    if (curieOrURI) {
+      if (curieOrURI.toLowerCase().startsWith('http')) {
+        if (as_markup)
+          return `[${curieOrURI}](${curieOrURI})`;
+
+        return `<a href="${curieOrURI}" target="_blank">${curieOrURI}</a>`;
+      }
+      else if (curieOrURI.includes(':')) {
+        const [prefix, reference] = curieOrURI.split(':',2);
+        if (prefix && reference && (prefix in this.schema.prefixes)) {
+          // Lookup curie 
+          let url = this.schema.prefixes[prefix]['prefix_reference'] + reference;
+          if (as_markup)
+            return `[${curieOrURI}](${url})`;
+          return `<a href="${url}" target="_blank">${curieOrURI}</a>`;
+        }
+        else
+          return `${curieOrURI}`;
+      }
+    }
+    return '';
+  }
+
   /**
    * Presents reference guide in a popup.
    * @param {String} mystyle simple css stylesheet commands to override default.
@@ -1088,9 +1113,11 @@ class DataHarmonizer {
       for (const slot of section.children) {
         const slot_dict = this.getCommentDict(slot);
 
+        const slot_uri = this.renderSemanticID(slot_dict.slot_uri);
+
         row_html += '<tr>';
         if (this.columnHelpEntries.includes('column')) {
-          row_html += `<td class="label">${slot_dict.title}</td>`;
+          row_html += `<td class="label">${slot_dict.title}<br/>${slot_uri}</td>`;
         }
         if (this.columnHelpEntries.includes('description')) {
           row_html += `<td>${slot_dict.description}</td>`;
@@ -1868,6 +1895,15 @@ class DataHarmonizer {
       )}</strong>: ${field.title || field.name}</p>`;
     }
 
+    // Requires markup treatment of URLS.  Issue: this is getting rendered
+    // wrong.
+    const slot_uri = this.renderSemanticID(field.slot_uri, true);
+    if (field.slot_uri && this.columnHelpEntries.includes('slot_uri')) {
+      ret += `<p><strong data-i18n="help-sidebar__column">${i18next.t(
+        'help-sidebar__slot_uri'
+      )}</strong>: ${slot_uri}</p>`;
+    }
+
     if (field.description && this.columnHelpEntries.includes('description')) {
       ret += `<p><strong data-i18n="help-sidebar__description">${i18next.t(
         'help-sidebar__description'
@@ -1907,7 +1943,8 @@ class DataHarmonizer {
     let guide = {
       title: field.title,
       name: field.name,
-      description: field.description || '',
+      slot_uri: field.slot_uri,
+      description: urlToClickableAnchor(field.description) || '',
       guidance: '',
       examples: '',
       sources: '',
@@ -1978,6 +2015,10 @@ class DataHarmonizer {
         return '<p>' + paragraph + '</p>';
       })
       .join('\n');
+
+    // Makes full URIs that aren't in markup into <a href>
+    if (guide.guidance)
+      guide.guidance = urlToClickableAnchor(guide.guidance);
 
     if (field.examples && field.examples.length) {
       let examples = [];

--- a/lib/Toolbar.js
+++ b/lib/Toolbar.js
@@ -818,6 +818,10 @@ class Toolbar {
     for (const dh in this.context.dhs) {
       this.context.dhs[dh].renderReference();
     }
+    // Prevents another popup on repeated click if user focuses away from
+    // previous popup.
+    return false; 
+
   }
 
   showError(prefix, message) {

--- a/lib/utils/content.js
+++ b/lib/utils/content.js
@@ -53,7 +53,7 @@ export const urlToClickableAnchor = (string) => {
       'g'
     );
     // Replace the URL with an anchor tag in the string
-    string = string.replace(regex, `<a href="${escapedURL}">${escapedURL}</a>`);
+    string = string.replace(regex, `<a href="${escapedURL}" target="_blank">${escapedURL}</a>`);
   });
 
   return string;

--- a/web/templates/canada_covid19/schema_core.yaml
+++ b/web/templates/canada_covid19/schema_core.yaml
@@ -8,8 +8,34 @@ in_language:
 imports:
 - 'linkml:types'
 prefixes:
-  linkml: 'https://w3id.org/linkml/'
-  GENEPIO: 'http://purl.obolibrary.org/obo/GENEPIO_'
+  linkml: https://w3id.org/linkml/
+  BTO: http://purl.obolibrary.org/obo/BTO_
+  CIDO: http://purl.obolibrary.org/obo/CIDO_
+  CLO: http://purl.obolibrary.org/obo/CLO_
+  DOID: http://purl.obolibrary.org/obo/DOID_
+  ECTO: http://purl.obolibrary.org/obo/ECTO_
+  EFO: http://purl.obolibrary.org/obo/EFO_
+  ENVO: http://purl.obolibrary.org/obo/ENVO_
+  FOODON: http://purl.obolibrary.org/obo/FOODON_
+  GAZ: http://purl.obolibrary.org/obo/GAZ_
+  GENEPIO: http://purl.obolibrary.org/obo/GENEPIO_
+  GSSO: http://purl.obolibrary.org/obo/GSSO_
+  HP: http://purl.obolibrary.org/obo/HP_
+  IDO: http://purl.obolibrary.org/obo/IDO_
+  MP: http://purl.obolibrary.org/obo/MP_
+  MMO: http://purl.obolibrary.org/obo/MMO_
+  MONDO: http://purl.obolibrary.org/obo/MONDO_
+  MPATH: http://purl.obolibrary.org/obo/MPATH_
+  NCIT: http://purl.obolibrary.org/obo/NCIT_
+  NCBITaxon: http://purl.obolibrary.org/obo/NCBITaxon_
+  NBO: http://purl.obolibrary.org/obo/NBO_
+  OBI: http://purl.obolibrary.org/obo/OBI_
+  OMRSE: http://purl.obolibrary.org/obo/OMRSE_
+  PCO: http://purl.obolibrary.org/obo/PCO_
+  TRANS: http://purl.obolibrary.org/obo/TRANS_
+  UBERON: http://purl.obolibrary.org/obo/UBERON_
+  UO: http://purl.obolibrary.org/obo/UO_
+  VO: http://purl.obolibrary.org/obo/VO_
 classes:
   dh_interface:
     name: dh_interface

--- a/web/translations/translations.json
+++ b/web/translations/translations.json
@@ -243,6 +243,10 @@
     "en": "Menus",
     "fr": "Menus"
   },
+  "help-picklists": {
+    "en": "Controlled vocabulary picklists",
+    "fr": "Des listes de choix de vocabulaire contrôlé"
+  },
   "reference_guide_title": {
     "en": "Reference Guide for",
     "fr": "Guide de référence pour"

--- a/web/translations/translations.json
+++ b/web/translations/translations.json
@@ -223,6 +223,10 @@
     "en": "Column",
     "fr": "Colonne"
   },
+  "help-sidebar__slot_uri": {
+    "en": "Semantic ID",
+    "fr": "ID sémantique"
+  },
   "help-sidebar__description": {
     "en": "Description",
     "fr": "Description"


### PR DESCRIPTION
This is provided in the slot/column level documentation.  

A hyperlink is included for those schemas that have included schema prefixes list of curies used in slot_uri's as well as class_uri and enumeration meaning attributes.