### PR TITLE
Fix for multiselect menu indentation

### DIFF
--- a/lib/AppContext.js
+++ b/lib/AppContext.js
@@ -551,6 +551,9 @@ export default class AppContext {
    * Recursively flatten vocabulary into an array of strings, with each
    * string's level of depth in the vocabulary being indicated by leading
    * spaces.
+   * ISSUE August, 2025: It seems Handsontable css no longer indents
+   * display of choice.text leading spaces.  Remedied in DataHarmonizer.js 
+   * enableMultiSelection()
    * FUTURE possible functionality:
    * Both validation and display of picklist item becomes conditional on
    * other picklist item if "depends on" indicated in picklist item/branch.

--- a/lib/DataHarmonizer.js
+++ b/lib/DataHarmonizer.js
@@ -62,7 +62,7 @@ import {
   KeyValueListEditor,
   keyValueListValidator,
   keyValueListRenderer,
-  multiKeyValueListRenderer,
+  //multiKeyValueListRenderer,
 } from './editors';
 
 Handsontable.cellTypes.registerCellType('key-value-list', {
@@ -1541,44 +1541,64 @@ class DataHarmonizer {
 
       col.source = null;
 
+      /* A field with .sources indicates that one or more enumerations 
+       * are involved, and so it should use a select or multiselect 
+       * pulldown menu.
+       * Both have to handle indentation of choices where enumeration
+       * has "is_a" parents.
+       * Note that single select pulldown list handled by enablemultiselection()
+       * has div class="handsontableEditor listbox handsontable".
+       */ 
       if (field.sources) {
-        const options = field.sources.flatMap((source) => {
-          if (field.permissible_values[source])
-            return Object.values(field.permissible_values[source]).reduce(
-              (acc, item) => {
-                acc.push({
-                  label: titleOverText(item),
-                  value: titleOverText(item),
-                  _id: item.text,
-                });
-                return acc;
-              },
-              []
-            );
-          else {
-            alert(
-              'Schema Error: Slot mentions enumeration ' +
-                source +
-                ' but this was not found in enumeration dictionary, or it has no selections'
-            );
-            return [];
-          }
-        });
 
+        let options = [];
+
+        field.sources.forEach((source) => {
+          let stack = [];
+
+          if (!(source in field.permissible_values)) {
+            alert(`Schema Error: Slot mentions enumeration ${source} but this was not found in enumeration dictionary, or it has no selections`);
+          }
+          else
+            Object.values(field.permissible_values[source]).forEach(
+              (permissible_value) => {
+                let level = 0;
+                const code = permissible_value.text;
+                if ('is_a' in permissible_value) {
+                  level = stack.indexOf(permissible_value.is_a) + 1;
+                  stack.splice(level + 1, 1000, code);
+                } else {
+                  stack = [code];
+                }
+
+                options.push({
+                  label: '. '.repeat(level) + (permissible_value.title || code),
+                  value: code,
+                  _id: code, // Used by picklist renderer.
+                });
+
+              }
+            );
+        });
+        //console.log("picklist for ", field.name, options, field.multivalued)
         col.source = options;
         if (field.multivalued === true) {
           col.editor = 'text';
-          col.renderer = multiKeyValueListRenderer(field);
+          col.renderer = 'autocomplete';
+          //col.renderer = multiKeyValueListRenderer(field);
           col.meta = {
             datatype: 'multivalued', // metadata
           };
         } else {
           col.type = 'key-value-list';
+          col.renderer = 'autocomplete';
+          //keyValueListRenderer(field);
           if (
             !field.sources.includes('NullValueMenu') ||
             field.sources.length > 1
           ) {
-            col.trimDropdown = false; // Allow expansion of pulldown past field width
+            // Allow expansion of pulldown past field width
+            col.trimDropdown = false; 
           }
         }
       }
@@ -1588,7 +1608,7 @@ class DataHarmonizer {
         col.allowInvalid = true; // making a difference?
         col.flatpickrConfig = {
           dateFormat: this.dateFormat, //yyyy-MM-dd
-          enableTime: false,
+          eenablemultiselectionnableTime: false,
         };
       } else if (field.datatype == 'xsd:dateTime') {
         col.type = 'dh.datetime';
@@ -1641,16 +1661,39 @@ class DataHarmonizer {
           let content = '';
           if (self.slots[col].sources) {
             self.slots[col].sources.forEach((source) => {
-              Object.values(self.slots[col].permissible_values[source]).forEach(
-                (permissible_value) => {
-                  const field = permissible_value.text;
-                  const field_trim = field.trim();
+              /* This is somewhat more efficient but relies on flatVocabulary 
+              having spaces to pad selections. As of Aug 2025 It seems handsontable html
+              styling for multiselect element is no longer showing spaces, or
+              some custom css for space handling is gone.
+              for (value in self.slots[col].flatVocabulary){
+                  const field_trim = value.trim();
                   let selected = selections.includes(field_trim)
                     ? 'selected="selected"'
                     : '';
-                  content += `<option value="${field_trim}" ${selected}'>${titleOverText(
-                    permissible_value
-                  )}</option>`;
+                  content += `<option value="${field_trim}" ${selected}'>${value}</option>`;
+
+              }
+              */
+              // Need to handle both text as code, and title or text as indented label,
+              let stack = [];
+
+              Object.values(self.slots[col].permissible_values[source]).forEach(
+                (permissible_value) => {
+                  let level = 0;
+                  const code = permissible_value.text;
+                  if ('is_a' in permissible_value) {
+                    level = stack.indexOf(permissible_value.is_a) + 1;
+                    stack.splice(level + 1, 1000, code);
+                  } else {
+                    stack = [code];
+                  }
+
+                  //const field_trim = field.trim();
+                  const selected = selections.includes(code)
+                    ? 'selected="selected"'
+                    : '';
+                  const title = '&nbsp;&nbsp;'.repeat(level) + (permissible_value.title || code)
+                  content += `<option value="${code}" ${selected}'>${title}</option>`;
                 }
               );
             });

--- a/lib/DataHarmonizer.js
+++ b/lib/DataHarmonizer.js
@@ -1608,7 +1608,7 @@ class DataHarmonizer {
         col.allowInvalid = true; // making a difference?
         col.flatpickrConfig = {
           dateFormat: this.dateFormat, //yyyy-MM-dd
-          eenablemultiselectionnableTime: false,
+          enableTime: false,
         };
       } else if (field.datatype == 'xsd:dateTime') {
         col.type = 'dh.datetime';


### PR DESCRIPTION
It appears that at some point in last year a Handsontable style sheet or code change stopped indenting hierarchic menu items. This remedies that.